### PR TITLE
myssh 0.0.3

### DIFF
--- a/Formula/myssh.rb
+++ b/Formula/myssh.rb
@@ -1,12 +1,16 @@
 class Myssh < Formula
   desc "Checking for existing SSH keys"
   homepage "https://github.com/devtical/myssh"
-  url "https://github.com/devtical/myssh/releases/download/v0.0.1/myssh-x86_64-apple-darwin.tar.gz"
-  version "0.0.1"
-  sha256 "66c3a0debc369e8f3f4cccfd0bfbe87d94ae82c11fe046dd3c69aaa059830b2c"
+  url "https://github.com/devtical/myssh/releases/download/v0.0.3/myssh-x86_64-apple-darwin.tar.gz"
+  version "0.0.3"
+  sha256 "f25b60aa14eee0b4d4d9b9195348874d387d33fc6390eb8df1664cd0ffd3fd79"
   license "Apache-2.0"
 
   def install
     bin.install "myssh"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/myssh --version")
   end
 end


### PR DESCRIPTION
## Summary
- update myssh to v0.0.3
- add basic version test block

## Testing
- `ruby -c Formula/myssh.rb`
- `/tmp/brew/bin/brew audit --strict myssh`


------
https://chatgpt.com/codex/tasks/task_e_689f09c7841c832c96cce83aa588a8fd